### PR TITLE
Fix for 'ReferenceError: client is not defined' at server.js:65

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -60,6 +60,7 @@ app._initializeWSS = function(server) {
               }
             );
             self._clients[key][id] = { token: token, ip: ip, user_id: user_id, id: id };
+			var client = self._clients[key][id];
             self._ips[ip]++;
             socket.send(JSON.stringify({ type: 'OPEN' }));
             self._notifyAddUser(key, client);


### PR DESCRIPTION
Fixes:

ReferenceError: client is not defined at /lib/server.js:65:38
